### PR TITLE
Insert missing space between # and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-#Hacking the Visual Norm
-##### About the different ways that you can take your data visualization beyond the default
+# Hacking the Visual Norm
+
+### About the different ways that you can take your data visualization beyond the default
 
 In this repo you can find the slides and underlying code for my talk called "Hacking the Visual Norm". It might take a few seconds to load, but you should see something within ±10 seconds (note that the presentation has a few CPU heavy slides, especially those with continuously moving objects).
 
-####Please, please look at these slides in Chrome
+### Please, please look at these slides in Chrome
 
 Tested with Chrome, Firefox and Safari. Definitely meant to be seen in Chrome. Even more so at a resolution of 1920x1080
 
@@ -11,22 +12,22 @@ Tested with Chrome, Firefox and Safari. Definitely meant to be seen in Chrome. E
 
 [![Hacking the Visual Norm - slides](img/hacking_the_norm.png "Hacking the Visual Norm - slides")](https://nbremer.github.io/hackingthevisualnorm/)
 
-###Extras
+### Extras
 
 With interactive slides build with HTML, CSS & JavaScript (and d3 v3 & 4) there are a few extra things possible. Of course there are also a few things that don't work in all browsers (but I really try :) )
 
-#####Interactivity
+##### Interactivity
 
 - In the "voronoi-scatter-plot" slide/section where you see a simple scatterplot there are mouseovers after clicking next once. This section is about creating better UX with mouseovers by using the voronoi technique, so the next clicks will have progressively better tooltips, so start hovering :)
 - in the "voronoi-baby-names" and "brush-baby-names" slides showing the end state of my baby names project you can hover over lines to see which names the lines represent. Click a name to see that name's entire stay in the top 10. Als move or increase the size of the bottom small window to see more or less years at the same time
 - In the slides "brush-bar-update-data" and (3 clicks on) "brush-bar-clip-data" there are rainbow bar charts. Here you can move the window in the mini bar chart up and down, increase its size you can see the main bar chart update. Although the 1st one doesn't have good UX (that's the point I make in my presentation ;) that was just my first approach)
 - In the slide "loom-lotr-final" showing the final result of my LotR project you can hover over the locations and fellowship members to see more details
 
-#####Autmatic transitions
+##### Autmatic transitions
 
 There's one automatic slide in the presentation (i.e. something that automatically goes through "fragments" on a slide). It's the third slide "radial-plot-evolution" with the radial bar chart. After clicking once the visual will morph into its final state until it has reached the final static fully realized chart
 
-#####Notes
+##### Notes
 
 If you're looking at the presentation at a different resolution than 1920x1080 the text has the tendency to twitch whenever you click on the next arrow and an animation occurs within the same slide. Not sure why this is...
 


### PR DESCRIPTION
Hello @nbremer ,

I notice that you have a bunch of `#` signs in the `README.md`. If you were trying to render different HTML header levels, all you were missing are spaces.

I have inserted a single space between `#` signs and headers to get `h1`, `h3`, and `h5` headers in the `README.md`. I believe now it looks like the way you wanted and visually coherent.

If you would like to integrate this pull request ...